### PR TITLE
Add example query for endpoint-method decorator

### DIFF
--- a/endpoint-get.rq
+++ b/endpoint-get.rq
@@ -1,0 +1,12 @@
+#+ endpoint-method: GET
+
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX schema: <http://schema.org/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?band ?album ?genre WHERE {
+  ?band rdf:type dbo:Band .
+  ?album rdf:type schema:MusicAlbum .
+  ?band dbo:genre ?genre .
+  ?album dbo:artist ?band .
+} LIMIT 100


### PR DESCRIPTION
`endpoint-method` decorator was added to grlc via [#450](https://github.com/CLARIAH/grlc/pull/450), and an example was included, but was not yet merged.